### PR TITLE
Implement jpeg quality reducer

### DIFF
--- a/src/components/nav/Navigation.vue
+++ b/src/components/nav/Navigation.vue
@@ -63,7 +63,7 @@ function resetApp() {
           New File
         </button>
         <button class="button" @click="file.revert()">
-          Undo all changes
+          Undo All Actions
         </button>
         <hr>
         <button class="button" @click="file.export()">

--- a/src/components/nav/Navigation.vue
+++ b/src/components/nav/Navigation.vue
@@ -63,7 +63,7 @@ function resetApp() {
           New File
         </button>
         <button class="button" @click="file.revert()">
-          Revert Changes
+          Undo all changes
         </button>
         <hr>
         <button class="button" @click="file.export()">
@@ -77,15 +77,15 @@ function resetApp() {
           Clear
         </button>
       </WithDropdown>
-      <!-- <button class="button btn-white">
-        EDIT
+      <button class="button btn-white">
+        Presets
       </button>
       <button class="button btn-white">
-        SETTINGS
+        Settings
       </button>
       <button class="button btn-white">
-        HELP
-      </button> -->
+        Help
+      </button>
     </div>
 
     <!-- <div class="divider" />

--- a/src/components/nav/Navigation.vue
+++ b/src/components/nav/Navigation.vue
@@ -10,11 +10,13 @@ import { useFile } from '../../store/file'
 import WithDropdown from '../generic/WithDropdown.vue'
 import { useLoading } from '../../store/loading'
 import { useEffects } from '../../store/effects'
+import { useHistory } from '../../store/history'
 
 const file = useFile()
 const effects = useEffects()
 const canvas = useCanvas()
 const loading = useLoading()
+const history = useHistory()
 
 function resetApp() {
   // Reset file
@@ -69,7 +71,7 @@ function resetApp() {
         <button class="button" @click="file.export()">
           Save
         </button>
-        <button class="button" @click="file.export()">
+        <button class="button" @click="file.export(true)">
           Save As
         </button>
         <hr>
@@ -116,11 +118,11 @@ function resetApp() {
         <IconZoomOut />
       </button>
 
-      <button class="button btn-white btn-icon" data-title-bottom="Undo">
+      <button class="button btn-white btn-icon" data-title-bottom="Undo" :disabled="!history.canUndo" @click="history.undo">
         <IconUndoVariant />
       </button>
 
-      <button class="button btn-white btn-icon" data-title-bottom="Redo">
+      <button class="button btn-white btn-icon" data-title-bottom="Redo" :disabled="!history.canRedo" @click="history.redo">
         <IconRedoVariant />
       </button>
     </div>

--- a/src/components/nav/modules/SidebarFilter.vue
+++ b/src/components/nav/modules/SidebarFilter.vue
@@ -3,6 +3,9 @@ import { computed } from 'vue'
 import { IconRefresh } from '@iconify-prerendered/vue-mdi'
 import type { EffectDefinition } from '../../../store/effects'
 import { effectDefinitions, useEffects } from '../../../store/effects'
+import { debounce } from '../../../js/util'
+import { UpdateType, useHistory } from '../../../store/history'
+import { useFile } from '../../../store/file'
 
 const props = defineProps<{
   data: EffectDefinition
@@ -10,10 +13,25 @@ const props = defineProps<{
 }>()
 
 const effects = useEffects()
+const file = useFile()
+const history = useHistory()
 
 const effectValue = computed({
   get: () => effects.state[props.id].value,
-  set: value => effects.state[props.id].value = value,
+  set: debounce((value: number) => {
+    effects.state[props.id].value = value
+
+    file.afterDraw((imageData) => {
+      history.add({
+        imageData,
+        updates: [{
+          type: UpdateType.FILTER,
+          key: props.id,
+          value,
+        }],
+      })
+    })
+  }, 100),
 })
 
 function reset() {

--- a/src/components/nav/modules/SidebarFilter.vue
+++ b/src/components/nav/modules/SidebarFilter.vue
@@ -24,11 +24,11 @@ const effectValue = computed({
     file.afterDraw((imageData) => {
       history.add({
         imageData,
-        updates: [{
-          type: UpdateType.FILTER,
+        type: UpdateType.FILTER,
+        payload: {
           key: props.id,
           value,
-        }],
+        },
       })
     })
   }, 100),

--- a/src/components/nav/modules/SidebarTransform.vue
+++ b/src/components/nav/modules/SidebarTransform.vue
@@ -30,7 +30,7 @@ const rotation = computed({
       <input v-model="rotation" type="number">
     </div>
   </div>
-
+  <hr>
   <div class="sidebar-section">
     <div class="section-title">
       <strong>Flip</strong>

--- a/src/js/definitions.ts
+++ b/src/js/definitions.ts
@@ -2,3 +2,5 @@ export const LOAD = {
   upload: 'file-upload',
   export: 'file-export',
 } as const
+
+export type EmptyCallback = () => void

--- a/src/js/effects.ts
+++ b/src/js/effects.ts
@@ -87,8 +87,6 @@ function performDegradation(data: ImageData, quality: number): Promise<ImageData
     // Clamp quality to the allowed range between 0 and 100
     quality = clamp(0, quality, 100)
 
-    console.log(quality)
-
     const canvas = document.createElement('canvas')
     canvas.width = data.width
     canvas.height = data.height

--- a/src/js/effects.ts
+++ b/src/js/effects.ts
@@ -78,7 +78,7 @@ export async function degradeQuality(data: ImageData, quality: number, repetitio
 }
 
 // REVIEW This can be optimized if we don't create canvas & image on each run
-// Instead we could create them in the `defradeQualit` function above and simply
+// Instead we could create them in the `degradeQuality` function above and simply
 // pass them into this function.
 // Could potentially improve performance if we run the following function 50 times
 

--- a/src/js/effects.ts
+++ b/src/js/effects.ts
@@ -67,7 +67,7 @@ export async function degradeQuality(data: ImageData, quality: number, repetitio
   // Run degrataion once
   let degradedData = await performDegradation(data, quality)
 
-  if (repetitions <= 1)
+  if (repetitions === 1)
     return degradedData
 
   // Recursive run with the previous image data
@@ -81,26 +81,33 @@ export async function degradeQuality(data: ImageData, quality: number, repetitio
 // Instead we could create them in the `defradeQualit` function above and simply
 // pass them into this function.
 // Could potentially improve performance if we run the following function 50 times
+
 function performDegradation(data: ImageData, quality: number): Promise<ImageData> {
   return new Promise((resolve, reject) => {
     // Clamp quality to the allowed range between 0 and 100
     quality = clamp(0, quality, 100)
+
+    console.log(quality)
+
     const canvas = document.createElement('canvas')
     canvas.width = data.width
     canvas.height = data.height
+
     const ctx = canvas.getContext('2d')
 
     if (ctx) {
-      ctx.putImageData(data, data.width, data.height)
+      ctx.putImageData(data, 0, 0)
       // Export data s jpeg with the provided quality (or degradation :)
       const source = canvas.toDataURL('image/jpeg', quality / 100)
       const image = new Image()
       image.src = source
+
       image.onload = () => {
         // Save to canvas and get data back
-        ctx.drawImage(image, data.width, data.height)
+        ctx.drawImage(image, 0, 0, data.width, data.height)
         resolve(ctx.getImageData(0, 0, data.width, data.height))
       }
+
       image.onerror = () => reject(new Error('Failed to load updated image'))
     }
   })

--- a/src/js/util.ts
+++ b/src/js/util.ts
@@ -37,3 +37,22 @@ export function and(...checks: boolean[]) {
 export function or(...checks: boolean[]) {
   return checks.some(b => b)
 }
+
+/**
+ * @param {*} ctx The context
+ * @param {function} func The function to execute after the debounce time
+ * @param {number} delay The amount of time to wait
+ * @return {function} The debounced function
+ */
+export function debounce(func: (...arg: any[]) => void, delay: number) {
+  let timeout: NodeJS.Timeout
+
+  return (...arg: []) => {
+    if (timeout)
+      clearTimeout(timeout)
+
+    timeout = setTimeout(() => {
+      func(...arg)
+    }, delay)
+  }
+}

--- a/src/store/effects.ts
+++ b/src/store/effects.ts
@@ -177,10 +177,18 @@ export const useEffects = defineStore('effects', () => {
   // Store active tab
   const activeTab = ref<string>(tabs[2].id)
 
+  // Store information related to noise
+  const noise = reactive({
+    amount: 0,
+    isGrayscale: false,
+    type: 'random',
+  })
+
   return {
     activeTab,
     state,
     reset,
     collectEffects,
+    noise,
   }
 })

--- a/src/store/file.ts
+++ b/src/store/file.ts
@@ -194,22 +194,25 @@ export const useFile = defineStore('file', () => {
    */
   function revert() {
     const ctx = getCanvasContext()
-    if (!ctx || !img.value)
+    if (!ctx || !img.value || !originalImg.value)
       return
 
     // Reset any changes made and re-append image
     const effects = useEffects()
     effects.reset()
 
-    const { width, height } = defaultScale()
-    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
-    ctx.drawImage(
-      img.value,
-      (ctx.canvas.width / 2) - (width / 2),
-      (ctx.canvas.height / 2) - (height / 2),
-      width,
-      height,
-    )
+    // ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+    img.value.src = originalImg.value.src
+
+    img.value.onload = () => draw()
+
+    // ctx.drawImage(
+    //   originalImg.value,
+    //   (ctx.canvas.width / 2) - (width / 2),
+    //   (ctx.canvas.height / 2) - (height / 2),
+    //   width,
+    //   height,
+    // )
   }
 
   /**

--- a/src/store/file.ts
+++ b/src/store/file.ts
@@ -17,7 +17,7 @@ function sendErrorMessage(event: ErrorEvent) {
   const toast = useToast()
   toast.push({
     type: 'error',
-    message: event.message,
+    message: event?.message ?? 'Idk err',
   })
 }
 
@@ -105,7 +105,7 @@ export const useFile = defineStore('file', () => {
     }
 
     img.value = image
-    originalImg.value = image
+    originalImg.value = image.cloneNode(true) as HTMLImageElement
     draw()
   }
 
@@ -228,12 +228,10 @@ export const useFile = defineStore('file', () => {
       return
 
     // Reset any changes made and re-append image
-    const effects = useEffects()
-    effects.reset()
+    useEffects().reset()
+    useHistory().reset()
 
-    // ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
     img.value.src = originalImg.value.src
-
     img.value.onload = () => draw()
 
     // ctx.drawImage(

--- a/src/store/file.ts
+++ b/src/store/file.ts
@@ -5,6 +5,7 @@ import { useToast } from './toast'
 import { getCanvasContext } from './canvas'
 import { useLoading } from './loading'
 import { useEffects } from './effects'
+import { useHistory } from './history'
 
 type AfterDrawCallback = (imgData: ImageData) => void
 
@@ -81,12 +82,15 @@ export const useFile = defineStore('file', () => {
   })
 
   async function upload() {
-    const { add, del } = useLoading()
-    add(LOAD.upload)
+    const loading = useLoading()
+    useEffects().reset()
+    useHistory().reset()
+
+    loading.add(LOAD.upload)
     triggerUpload()
       .then(update)
       .finally(() => {
-        del(LOAD.upload)
+        loading.del(LOAD.upload)
       })
   }
 

--- a/src/store/history.ts
+++ b/src/store/history.ts
@@ -1,4 +1,7 @@
 import { defineStore } from 'pinia'
+import { computed, reactive, ref } from 'vue'
+import { useEffects } from './effects'
+import { useFile } from './file'
 
 /**
  * History tracks what changes user made and allows them to backtrack
@@ -12,6 +15,96 @@ import { defineStore } from 'pinia'
  * This allows us to keep things simple.
  */
 
-export const useHistory = defineStore('history', () => {
+export enum UpdateType {
+  FILTER,
+  TRANSFORM,
+  NOISE,
+}
 
+interface UpdateEntry {
+  type: UpdateType
+  key: string
+  value: number
+}
+
+interface HistoryEntry {
+  // Store the canvas
+  imageData: ImageData
+  updates: UpdateEntry[]
+}
+
+export const useHistory = defineStore('history', () => {
+  const entries = reactive<{ value: HistoryEntry[] }>({ value: [] })
+  const historyIndex = ref(0)
+  const isRestoring = ref(false)
+
+  // Checks if we can move in history
+  const canUndo = computed(() => !!entries.value[historyIndex.value - 1])
+  const canRedo = computed(() => !!entries.value[historyIndex.value + 1])
+
+  // Get the current history entry
+  const now = computed(() => entries.value.at(historyIndex.value))
+
+  function add(entry: HistoryEntry) {
+    // Do not save new entries when restoring, as that would add a new
+    // history entry of all the values being restored
+    if (isRestoring.value)
+      return
+
+    entries.value.push(entry)
+    historyIndex.value++
+  }
+
+  // Other stores
+  const effects = useEffects()
+  const file = useFile()
+
+  function restore() {
+    const savedEntry = entries.value[historyIndex.value]
+    const { imageData, updates } = savedEntry
+
+    // First restore values to UI elements
+    for (const update of updates) {
+      switch (update.type) {
+        case UpdateType.FILTER: {
+          effects.state[update.key].value = update.value
+          break
+        }
+
+        case UpdateType.NOISE: {
+          break
+        }
+      }
+    }
+
+    // Then overwrite canvas data
+    file.update(imageData)
+    isRestoring.value = false
+  }
+
+  function undo() {
+    if (canUndo.value) {
+      isRestoring.value = true
+      historyIndex.value--
+      restore()
+    }
+  }
+
+  function redo() {
+    if (canRedo.value) {
+      isRestoring.value = true
+      historyIndex.value++
+      restore()
+    }
+  }
+
+  return {
+    add,
+    undo,
+    redo,
+    now,
+    canUndo,
+    canRedo,
+    entries,
+  }
 })

--- a/src/store/history.ts
+++ b/src/store/history.ts
@@ -21,16 +21,11 @@ export enum UpdateType {
   NOISE,
 }
 
-interface UpdateEntry {
-  type: UpdateType
-  key: string
-  value: number
-}
-
 interface HistoryEntry {
   // Store the canvas
   imageData: ImageData
-  updates: UpdateEntry[]
+  type: UpdateType
+  payload: Record<string, any>
 }
 
 export const useHistory = defineStore('history', () => {
@@ -61,19 +56,24 @@ export const useHistory = defineStore('history', () => {
 
   function restore() {
     const savedEntry = entries.value[historyIndex.value]
-    const { imageData, updates } = savedEntry
+    const { imageData, type, payload } = savedEntry
 
     // First restore values to UI elements
-    for (const update of updates) {
-      switch (update.type) {
-        case UpdateType.FILTER: {
-          effects.state[update.key].value = update.value
-          break
-        }
+    // for (const update of updates) {
+    switch (type) {
+      // Payload is a key & value pair
+      case UpdateType.FILTER: {
+        effects.state[payload.key].value = payload.value
+        break
+      }
 
-        case UpdateType.NOISE: {
-          break
-        }
+      case UpdateType.NOISE: {
+        Object.assign(effects.noise, payload)
+        break
+      }
+
+      case UpdateType.TRANSFORM: {
+        break
       }
     }
 
@@ -98,6 +98,10 @@ export const useHistory = defineStore('history', () => {
     }
   }
 
+  function reset() {
+    entries.value = []
+  }
+
   return {
     add,
     undo,
@@ -106,5 +110,6 @@ export const useHistory = defineStore('history', () => {
     canUndo,
     canRedo,
     entries,
+    reset,
   }
 })

--- a/src/style/app/nav/_sidebar.scss
+++ b/src/style/app/nav/_sidebar.scss
@@ -5,6 +5,14 @@
   // padding: 0 0 10px;
   padding-bottom: 10px;
 
+  hr {
+    display: block;
+    width: 100%;
+    border: none;
+    margin-bottom: 20px;
+    border-bottom: 1px solid var(--color-border);
+  }
+
   .sidebar-tabs {
     @include grid(0, 3);
     margin-bottom: 20px;
@@ -62,7 +70,9 @@
   .sidebar-section {
     display: block;
     width: 100%;
-    margin-bottom: 30px;
+    margin: 0;
+    padding: 0;
+    margin-bottom: 20px;
   }
 
   .filter-inputs {
@@ -95,16 +105,12 @@
         height: 15px;
         cursor: pointer;
         border: none;
-        // border: none;
-        // transform: scale(1);
         background-color: var(--color-border-light);
         background: var(--color-border-light);
       }
 
       &::-moz-range-track,
       &::-webkit-slider-runnable-track {
-        // height: 5px !important;
-        // width: 100%;
         background-color: var(--color-border);
         background: var(--color-border);
         border-color: var(--color-border-light);

--- a/src/style/app/nav/sidebar/_noise.scss
+++ b/src/style/app/nav/sidebar/_noise.scss
@@ -38,4 +38,14 @@
     padding: 0 var(--padding);
     margin-bottom: 20px;
   }
+
+  .quality-wrap {
+    @include grid(10px, 1fr 32px);
+    align-items: center;
+
+    span {
+      text-align: right;
+      font-size: 1.2rem;
+    }
+  }
 }

--- a/src/style/generic/button/_button.scss
+++ b/src/style/generic/button/_button.scss
@@ -3,7 +3,7 @@
 
 .button {
   @include font(500);
-  @include t();
+  @include t(0.075);
   @include flex(5px, center);
   // border-radius: var(--radius-tn);
   height: 30px;
@@ -25,6 +25,7 @@
     opacity: 0.5;
   }
 
+  &.is-active,
   &:hover {
     color: var(--color-text);
     background-color: var(--color-bg-light-hover);

--- a/src/style/generic/button/_button.scss
+++ b/src/style/generic/button/_button.scss
@@ -22,6 +22,7 @@
 
   &:disabled {
     pointer-events: none !important;
+    opacity: 0.5;
   }
 
   &:hover {

--- a/src/style/generic/form/index.scss
+++ b/src/style/generic/form/index.scss
@@ -9,6 +9,13 @@
   margin-top: 10px;
 }
 
+label {
+  @include font(400);
+  display: block;
+  font-size: 1.1rem;
+  color: var(--color-text-light);
+}
+
 .form-item {
   display: block;
   position: relative;
@@ -19,11 +26,7 @@
   }
 
   label {
-    @include font(400);
-    display: block;
     margin-bottom: 5px;
-    font-size: 1.1rem;
-    color: var(--color-text-light);
   }
 }
 

--- a/todo.md
+++ b/todo.md
@@ -42,6 +42,7 @@
 - [] Image dragged in takes full size instead of being calculated correctly (smaller images tha canvas should not get up-sized)
 - [] Noise is not being applied (to BW / large images)
 - [] Revert() does not work
+- [] Reset all filters to default values when new image is uploaded
 
 ---
 

--- a/todo.md
+++ b/todo.md
@@ -40,8 +40,8 @@
 ## Bugs
 
 - [] Image dragged in takes full size instead of being calculated correctly (smaller images tha canvas should not get up-sized)
-- [] Noise is not being applied
-- [] 
+- [] Noise is not being applied (to BW / large images)
+- [] Revert() does not work
 
 ---
 


### PR DESCRIPTION
This PR adds a new slider in the Noise tab where you can reduce the image quality by saving the canvas with low JPEG quality coded. It also supports performing this action recursively.

Before this can get merged there are some things that need to be ironed out

- [x] Applying reduction again results in errors
- [ ] ~~The slider should be logarithmic because the reduction is not really noticeable until below 30. This should also help because while the UI shows the % as 0 to 100, I'd like the conversion to feel more like 0 to 1000. Meaning the bottom half of the slider should be values between 0.1 - 0.001 or something similar.~~
- [x] Reduction reset button does not do anything
- [x] Global `reset-to-default` button does not work for changes to the `file.img` itself